### PR TITLE
Building bottle from specified tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,7 @@ name: CI
 on: [push]
 
 env:
-  TAP_NAME: rnpgp/rnp
-  FORMULA_NAME: rnpgp/rnp/rnp
+  FORMULA: ./Formula/rnp.rb
   OPTS: ""
   BINTRAY_PACKAGE: rnp
   BINTRAY_DESCRIPTOR_FILENAME: bintray_descriptor.json
@@ -13,17 +12,13 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Installing dependencies
-      run: |
-        brew update
-        brew tap ${TAP_NAME}
-        brew install --build-bottle ${FORMULA_NAME} ${OPTS}
+    - name: Build the formula
+      run: brew install --build-bottle ${FORMULA}
     - name: Test the formula
-      run: brew test ${FORMULA_NAME}
+      run: brew test ${FORMULA}
     - name: Build the bottle
       run: |
-        brew install jq
-        brew bottle rnp --json
+        brew bottle --json --force-core-tap ${FORMULA}
         source ci/read_bottle_metadata.sh
         ci/build_bintray_descriptor.rb
     - name: Publish to Bintray

--- a/Formula/rnp.rb
+++ b/Formula/rnp.rb
@@ -4,8 +4,9 @@ class Rnp < Formula
           performance.].join(' ')
   homepage 'https://github.com/rnpgp/rnp'
   head 'https://github.com/rnpgp/rnp.git'
-  url 'https://github.com/rnpgp/rnp/archive/v0.12.0.tar.gz'
-  sha256 '148d8437f15159ee754e77be6b717db2baeaab4e6f5213b9f63fec52ed0b0a39'
+  url 'https://github.com/rnpgp/rnp.git',
+       :tag      => 'v0.12.0',
+       :revision => '586caec6cd728d54dbd281cafe17ee2e1f29dbf1'
 
   depends_on 'cmake' => :build
   depends_on 'json-c'
@@ -14,6 +15,11 @@ class Rnp < Formula
   def install
     jsonc = Formula['json-c']
     botan = Formula['botan']
+
+    tag = `git describe`
+    ohai "Building tag #{tag}"
+    # only required to set when can't be determined automatically
+    # version tag
 
     mkdir 'build' do
       system(

--- a/Formula/rnp.rb
+++ b/Formula/rnp.rb
@@ -4,7 +4,7 @@ class Rnp < Formula
           performance.].join(' ')
   homepage 'https://github.com/rnpgp/rnp'
   head 'https://github.com/rnpgp/rnp.git'
-  url 'https://github.com/rnpgp/rnp.git', tag: 'v0.13.0'
+  url 'https://github.com/rnpgp/rnp.git', tag: 'v0.13.1'
 
   depends_on 'cmake' => :build
   depends_on 'json-c'

--- a/Formula/rnp.rb
+++ b/Formula/rnp.rb
@@ -4,9 +4,7 @@ class Rnp < Formula
           performance.].join(' ')
   homepage 'https://github.com/rnpgp/rnp'
   head 'https://github.com/rnpgp/rnp.git'
-  url 'https://github.com/rnpgp/rnp.git',
-       :tag      => 'v0.12.0',
-       :revision => '586caec6cd728d54dbd281cafe17ee2e1f29dbf1'
+  url 'https://github.com/rnpgp/rnp.git', :tag => 'v0.13.0'
 
   depends_on 'cmake' => :build
   depends_on 'json-c'

--- a/Formula/rnp.rb
+++ b/Formula/rnp.rb
@@ -4,7 +4,7 @@ class Rnp < Formula
           performance.].join(' ')
   homepage 'https://github.com/rnpgp/rnp'
   head 'https://github.com/rnpgp/rnp.git'
-  url 'https://github.com/rnpgp/rnp.git', :tag => 'v0.13.0'
+  url 'https://github.com/rnpgp/rnp.git', tag: 'v0.13.0'
 
   depends_on 'cmake' => :build
   depends_on 'json-c'


### PR DESCRIPTION
I checked `homebrew-core` and didn't find any formulae there that would pick the latest tag. It;s not considered normal practice. I set both #head and #stable support.
#stable has explicitly defined tag 'v0.12.0'
#head version can be built with `brew install --HEAD --build-bottle ${FORMULA}` but we wouldn't want to publish it to Bintray, would we?
Closes #14 